### PR TITLE
Update compile.sh

### DIFF
--- a/host/compile.sh
+++ b/host/compile.sh
@@ -18,7 +18,6 @@ fi
 
 VAI_VERSION=1.1
 MODEL_ZIP=$(echo ${MODEL_NAME} | sed 's/_[1-9\.]\+G_/_/g').zip
-MODEL_UNZIP=$(echo ${MODEL_NAME} | sed "s/_${VAI_VERSION}//g")
 MODEL_UNZIP=$(echo ${MODEL_NAME} | sed "s/\(.*\)_${VAI_VERSION}\(.*\)/\1\2/")
 MODEL=$(echo $MODEL_NAME | cut -d'_' -f2)
 FRAMEWORK=$(echo $MODEL_NAME | cut -d'_' -f1)

--- a/host/compile.sh
+++ b/host/compile.sh
@@ -19,6 +19,7 @@ fi
 VAI_VERSION=1.1
 MODEL_ZIP=$(echo ${MODEL_NAME} | sed 's/_[1-9\.]\+G_/_/g').zip
 MODEL_UNZIP=$(echo ${MODEL_NAME} | sed "s/_${VAI_VERSION}//g")
+MODEL_UNZIP=$(echo ${MODEL_NAME} | sed "s/\(.*\)_${VAI_VERSION}\(.*\)/\1\2/")
 MODEL=$(echo $MODEL_NAME | cut -d'_' -f2)
 FRAMEWORK=$(echo $MODEL_NAME | cut -d'_' -f1)
 


### PR DESCRIPTION
the previous version will replace all _1.1 string in the input model name, which results in an error when the model name is tf_mobilenetv2_1.4_imagenet_224_224_1.16G_1.1 because this model name contains with _1.1 string.