### PR TITLE
modified get_kernel_name_from_elf() function so it works with longer kernel names

### DIFF
--- a/pynq_dpu/dpu.py
+++ b/pynq_dpu/dpu.py
@@ -68,7 +68,7 @@ def get_kernel_name_from_elf(model):
         The name of the ML model binary. Can be absolute or relative path.
 
     """
-    cmd = 'readelf {} -s | grep ' \
+    cmd = 'readelf {} -s --wide | grep ' \
         '"1: 0000000000000000     0 FILE    LOCAL  DEFAULT  ABS"'.format(model)
     line = subprocess.check_output(cmd, shell=True).decode()
     kernel_0 = line.split()[-1].lstrip("dpu_").rstrip(".s")


### PR DESCRIPTION
Currently if the compiled kernel name exceeds 25 characters the output of readelf truncates it, which loads a wrong .so file name into /usr/lib. Can fix it by adding `--wide` flag to the readelf command.