### PR TITLE
Update dpu_clk

### DIFF
--- a/upgrade/dpu_clk/dpu_clk
+++ b/upgrade/dpu_clk/dpu_clk
@@ -20,7 +20,7 @@ import os
 
 pll_clk = 1500000000
 
-pl0_ref_ctrl = int(os.popen("devmem2 0xff5e00c0 32").read(), 16)
+pl0_ref_ctrl = int(os.popen("devmem2 0xff5e00c0 w").read().split()[-1], 16)
 pl0_div0 = (pl0_ref_ctrl >> 8) & 0x3f
 
 ori_clk = int(os.popen("cat /sys/kernel/debug/clk/pl0_ref/clk_rate").read())
@@ -33,9 +33,9 @@ if ((sys.argv.__len__() == 2) and sys.argv[1].isdecimal()):
         target_div0 = int(pll_clk / target_clk)
         target_reg = pl0_ref_ctrl & 0xffffc0ff | (target_div0 << 8)
         #print("Target PL0_CLK %d" % target_clk)
-        os.system("devmem2 0xff5e00c0 32 " + str(hex(target_reg)))
+        os.system("devmem2 0xff5e00c0 w " + str(hex(target_reg)))
 else:
-    pl0_ref_ctrl = int(os.popen("devmem2 0xff5e00c0 32").read(), 16)
+    pl0_ref_ctrl = int(os.popen("devmem2 0xff5e00c0 w").read().split()[-1], 16)
     pl0_div0 = (pl0_ref_ctrl >> 8) & 0x3f
     act_clk = pll_clk / pl0_div0
     print("Real PL0_CLK %d" % act_clk)


### PR DESCRIPTION
`dpu_clk` was giving the next error:

```
root@pynq:/home/xilinx# dpu_clk 100
Illegal data type '3'.
Traceback (most recent call last):
  File "/usr/bin/dpu_clk", line 23, in <module>
    pl0_ref_ctrl = int(os.popen("devmem2 0xff5e00c0 32").read(), 16)
ValueError: invalid literal for int() with base 16: '/dev/mem opened.\nMemory mapped at address 0x7fa8e36000.\n'
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 145, in apport_excepthook
    os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640), 'wb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/var/crash/_usr_bin_dpu_clk.0.crash'

Original exception was:
Traceback (most recent call last):
  File "/usr/bin/dpu_clk", line 23, in <module>
    pl0_ref_ctrl = int(os.popen("devmem2 0xff5e00c0 32").read(), 16)
ValueError: invalid literal for int() with base 16: '/dev/mem opened.\nMemory mapped at address 0x7fa8e36000.\n'
```