### PR TITLE
Fixed file paths for caffe models in compile.sh

### DIFF
--- a/host/compile.sh
+++ b/host/compile.sh
@@ -60,8 +60,8 @@ unzip -o ${MODEL_ZIP}
 # pytorch model naming convention changes, so doing a wildflag
 if [ $FRAMEWORK = 'cf' ]; then
 	vai_c_caffe \
-		--prototxt ${MODEL_UNZIP}/fix/deploy.prototxt \
-		--caffemodel ${MODEL_UNZIP}/fix/deploy.caffemodel \
+		--prototxt ${MODEL_UNZIP}/quantized/deploy.prototxt \
+		--caffemodel ${MODEL_UNZIP}/quantized/deploy.caffemodel \
 		--arch /opt/vitis_ai/compiler/arch/DPUCZDX8G/${BOARD}/arch.json \
 		--output_dir . \
 		--net_name ${MODEL}


### PR DESCRIPTION
As of version 1.4 the file paths to caffe models provided in the model zoo has changed to putting the deploy.prototxt and deploy.caffemodel into the quantized folder. This simple typo fix will help first time users to not be confused when the script is unable to find the file path.