### PR TITLE
Fix overlay for xclbin files

### DIFF
--- a/pynq_dpu/dpu.py
+++ b/pynq_dpu/dpu.py
@@ -130,8 +130,12 @@ class DpuOverlay(pynq.Overlay):
         The destination folder by default is `/usr/lib`.
 
         """
-        abs_xclbin = self.overlay_dirname + "/" + \
-            self.overlay_basename.rstrip(".bit") + ".xclbin"
+        if self.overlay_basename.endswith(".xclbin"):
+            abs_xclbin = self.overlay_dirname + "/" + \
+                self.overlay_basename
+        else:
+            abs_xclbin = self.overlay_dirname + "/" + \
+                self.overlay_basename.rstrip(".bit") + ".xclbin"
         if not os.path.isfile(abs_xclbin):
             raise ValueError(
                 "File {} does not exist.".format(abs_xclbin))


### PR DESCRIPTION
When DpuOverlay is run, it works correctly if a bitstream file such as dpu.bit is specified, but there is a problem with xclbin files such as dpu.xclbin that causes an error.

This is due to the process of removing ".bit" directly from the file name and adding ".xclbin", resulting in the incorrect file name "dpu.xclbin.xclbin" being processed.

We have included a fix to not specifically add xclbin if ".xclbin" is present at the end of the filename.

Best regards.