### PR TITLE
Add notebooks and utility script for RefineDet and SemanticFPN

### DIFF
--- a/pynq_dpu/notebooks/dpu_refinedet.ipynb
+++ b/pynq_dpu/notebooks/dpu_refinedet.ipynb
@@ -1,0 +1,462 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0c1bdc8a-8956-44aa-90c8-d0c8b94db9d8",
+   "metadata": {},
+   "source": [
+    "# DPU example: RefineDet\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "268569cc-1804-400b-8def-a0247fd2a48b",
+   "metadata": {},
+   "source": [
+    "## Aim/s\n",
+    "* This notebooks shows an example of DPU applications. The application, as well as the DPU IP, is pulled from the official \n",
+    "[Vitis AI Github Repository](https://github.com/Xilinx/Vitis-AI).\n",
+    "* Description: RefineDet for object detection on VOC.\n",
+    "* Input size: 320x320\n",
+    "* Task: Object detection\n",
+    "\n",
+    "## References\n",
+    "* [Vitis AI Github Repository](https://www.xilinx.com/products/design-tools/vitis/vitis-ai.html).\n",
+    "\n",
+    "## Last revised\n",
+    "* Dec 14, 2023\n",
+    "    * Initial revision. MM, Alpha Data Parallel Systems Ltd.\n",
+    "\n",
+    "----"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14eb8aed-7b41-413f-b2d5-5dd2d492815d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import time\n",
+    "import glob\n",
+    "import random\n",
+    "import colorsys\n",
+    "import numpy as np\n",
+    "import IPython\n",
+    "from PIL import Image\n",
+    "\n",
+    "from pynq_dpu import DpuOverlay\n",
+    "\n",
+    "# Import helper functions form refinedet_utils.py\n",
+    "# Original file available as utils_tf.py in the Vitis AI Github repository.\n",
+    "from refinedet_utils import pboxes_vgg_voc, Encoder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bdee6de-47a5-40b1-b8fe-ff1282470dfc",
+   "metadata": {},
+   "source": [
+    "## 1. Prepare the overlay\n",
+    "We will download the overlay onto the board and prepare the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "664a261b-986d-4251-b158-0c80462fccb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ol = DpuOverlay('dpu.bit')\n",
+    "ol.load_model('refinedet_voc_tf.xmodel')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d36542b-7822-4c6c-86bc-5bbd8eddfd08",
+   "metadata": {},
+   "source": [
+    "## 2. Utility functions\n",
+    "\n",
+    "In this section, we will prepare a few functions and the input data for later use.\n",
+    "\n",
+    "First we need to load the class labels for the VOC dataset and determine the colors for annotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a619a9d-d8bb-41d1-b955-934e3b47ee04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_class(classes_path):\n",
+    "    '''\n",
+    "    Function to parse the VOC classes file to get the classification information\n",
+    "    for the model.\n",
+    "    \n",
+    "    Input:\n",
+    "        classes_path: string corresponding to the path to the class labels file.\n",
+    "        \n",
+    "    Returns:\n",
+    "        List of strings corresponding to the individual class labels.\n",
+    "    \n",
+    "    '''\n",
+    "    with open(classes_path) as f:\n",
+    "        class_names = f.readlines()\n",
+    "    class_names = [c.strip() for c in class_names]\n",
+    "    return class_names\n",
+    "\n",
+    "# Parse the classes file\n",
+    "classes_path = \"img/voc_classes.txt\"\n",
+    "class_names = get_class(classes_path)\n",
+    "\n",
+    "# Generate colors for each class\n",
+    "num_classes = len(class_names)\n",
+    "hsv_tuples = [(1.0 * x / num_classes, 1., 1.) for x in range(num_classes)]\n",
+    "colors = list(map(lambda x: colorsys.hsv_to_rgb(*x), hsv_tuples))\n",
+    "colors = list(map(lambda x: \n",
+    "                  (int(x[0] * 255), int(x[1] * 255), int(x[2] * 255)), \n",
+    "                  colors))\n",
+    "random.seed(0)\n",
+    "random.shuffle(colors)\n",
+    "random.seed(None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a73edfb-85ef-4b30-8e23-c173d6c16050",
+   "metadata": {},
+   "source": [
+    "Next we need to define helper functions to prepare the input images for the model.\n",
+    "At this stage we will also define a post-processing function to decode the output\n",
+    "of the model and draw the bounding boxes.\n",
+    "\n",
+    "The post-processing step for the RefineDet model is quite complex. To keep this\n",
+    "example notebook clear, the helper functions for post-processing are defined in\n",
+    "the [refinedet_utils.py](refinedet_utils.py) file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36d484de-092f-4b5c-a770-e92244dac606",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess(image, size=(320, 320)):\n",
+    "    '''\n",
+    "    Function to prepare the input for the RefineDet model.\n",
+    "    The input images are first resized then mean subtraction is used to\n",
+    "    shift the colour channel values.\n",
+    "    \n",
+    "    Args:\n",
+    "        image: 3 dimensional array corresponding to the input BGR image.\n",
+    "        size (optional): (new_width, new_height) tuple corresponding to \n",
+    "                         the size of the input the RefineDet model is\n",
+    "                         expecting. Set to 320x320 by default.\n",
+    "                         \n",
+    "    Returns:\n",
+    "        3 dimensional array corresponding to the input for RefineDet. The\n",
+    "        array has a shape of (new_height, new_width, 3).\n",
+    "    '''\n",
+    "    \n",
+    "    image = cv2.resize(image, size)\n",
+    "    image = image.astype('float32')\n",
+    "    R_MEAN = 123.68\n",
+    "    G_MEAN = 116.78 \n",
+    "    B_MEAN = 103.94\n",
+    "    mean = np.array([B_MEAN, G_MEAN, R_MEAN], dtype=np.float32)\n",
+    "    image = image - mean\n",
+    "    \n",
+    "    return image\n",
+    "\n",
+    "def postprocess(image, output_tensors, display, score_threshold=0.5):\n",
+    "    '''\n",
+    "    Function to decode the output of the model and annotate the original\n",
+    "    image with the bounding boxes, predicted labels and confidence score.\n",
+    "    \n",
+    "    Args:\n",
+    "        image: 3 dimensional array corresponding to the original input image.\n",
+    "        output_tensors: buffers allocated for the DPU to store the output of\n",
+    "                        the model.\n",
+    "        display: boolean flag set to annotate and display the input image.\n",
+    "        score_threshold (optional): float corresponding to the minimum \n",
+    "                        confidence in the prediction for annotation.\n",
+    "                        \n",
+    "    Returns:\n",
+    "        None, the annotated image is displayed when the display flag is set.\n",
+    "    \n",
+    "    '''\n",
+    "    \n",
+    "    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)\n",
+    "    original_height, original_width, _ = image.shape\n",
+    "    bbox_thick = int(0.6 * (original_height + original_width) / 600)\n",
+    "    \n",
+    "    arm_loc = output_tensors[0] # (1, 8500, 4)\n",
+    "    arm_cls = output_tensors[1] # (1, 8500, 2)\n",
+    "    odm_loc = output_tensors[2] # (1, 8500, 4)\n",
+    "    odm_cls = output_tensors[3] # (1, 8500, 21)\n",
+    "    \n",
+    "    pboxes = pboxes_vgg_voc()\n",
+    "    encoder = Encoder(pboxes)\n",
+    "    \n",
+    "    loc, label, prob = encoder.decode_batch(arm_cls, arm_loc, odm_cls, odm_loc, 0.45, 200, device=0)[0]\n",
+    "    valid_mask = np.logical_and((loc[:, 2] - loc[:, 0] > 0), (loc[:, 3] - loc[:, 1] > 0))\n",
+    "    \n",
+    "    for i in range(prob.shape[0]-1, -1,-1):\n",
+    "        if not valid_mask[i]: continue\n",
+    "            \n",
+    "        score = prob[i]\n",
+    "        if score < score_threshold: break\n",
+    "            \n",
+    "        xmin = loc[i][0] * original_width\n",
+    "        ymin = loc[i][1] * original_height\n",
+    "        xmax = loc[i][2] * original_width\n",
+    "        ymax = loc[i][3] * original_height\n",
+    "        class_id = int(label[i]) - 1\n",
+    "        \n",
+    "        if not display: continue\n",
+    "        \n",
+    "        color = colors[class_id]\n",
+    "        text = f'{class_names[label[i] - 1]}: {prob[i]:.4f}'\n",
+    "        \n",
+    "        cv2.rectangle(image, (int(xmin), int(ymin)), (int(xmax), int(ymax)), color, bbox_thick)\n",
+    "        \n",
+    "        cv2.putText(image,\n",
+    "                    text,\n",
+    "                    (int((xmax - xmin)/2), int((ymax-ymin)/2)),\n",
+    "                    fontFace=cv2.FONT_HERSHEY_SIMPLEX,\n",
+    "                    fontScale=0.6,\n",
+    "                    color=color,\n",
+    "                    thickness=bbox_thick)\n",
+    "        \n",
+    "    if display:\n",
+    "        IPython.display.display(Image.fromarray(image))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48f0651f-e2de-4e2e-9d37-c01a86ba2722",
+   "metadata": {},
+   "source": [
+    "Finally, use a search pattern to collect all the `JPEG` files for evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc7eccfd-ff69-4ea8-8daf-fad3a31bf3c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_pattern = f'img/*.JPEG'\n",
+    "original_images = glob.glob(search_pattern)\n",
+    "total_images = len(original_images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a12ce21a-e59d-4bc9-b1b2-9a980580d411",
+   "metadata": {},
+   "source": [
+    "## 3. Use VART\n",
+    "\n",
+    "Now we should be able to use VART to do object detection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b20dfbad-888e-440d-a8fb-908f44d176d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dpu = ol.runner\n",
+    "\n",
+    "input_tensors = dpu.get_input_tensors()\n",
+    "output_tensors = dpu.get_output_tensors()\n",
+    "\n",
+    "shape_in = input_tensors[0].dims\n",
+    "shape_out0 = output_tensors[0].dims\n",
+    "shape_out1 = output_tensors[1].dims\n",
+    "shape_out2 = output_tensors[2].dims\n",
+    "shape_out3 = output_tensors[3].dims"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fef7438f-f18a-4200-a415-0fc61a961667",
+   "metadata": {},
+   "source": [
+    "We can define a few buffers to store input and output data. They will be reused during multiple runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd15e3ee-2f85-4896-9f0c-2caa24f85e74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_data = [np.empty(shape_in, dtype=np.float32, order=\"C\")]\n",
+    "output_data = [np.empty(shape_out0, dtype=np.float32, order=\"C\"), \n",
+    "               np.empty(shape_out1, dtype=np.float32, order=\"C\"),\n",
+    "               np.empty(shape_out2, dtype=np.float32, order=\"C\"),\n",
+    "               np.empty(shape_out3, dtype=np.float32, order=\"C\")]\n",
+    "\n",
+    "image = input_data[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dc31fe7-0a4f-4bbd-b2e8-af2f814d3163",
+   "metadata": {},
+   "source": [
+    "Remember that we have a list of `original_images`. We can no define a new function `run()` which takes the image index as the input, prepares the image for the model, executes the DPU for the given input and finally post-processes the output of the DPU. With the argument \n",
+    "`display` set to `True`, the original image with the bounding boxes and class labels and \n",
+    "confidence scores can be rendered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f65d0061-8540-46c1-a544-3d00fa7dd13a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run(image_index, display=False):\n",
+    "    '''\n",
+    "    Function to handle a single input for the DPU and process the output of the run.\n",
+    "    \n",
+    "    Args:\n",
+    "        image_index: int corresonding to the index of the collected images to be processed.\n",
+    "        display (optional): boolean flag set to annotate and display the input image.\n",
+    "        \n",
+    "    Returns:\n",
+    "        None, the annotated image is displayed when the display flag is set.\n",
+    "        \n",
+    "    Raises:\n",
+    "        AssertionError: when the provided image_index is larger than the number of potential\n",
+    "                        input images found.\n",
+    "    \n",
+    "    '''\n",
+    "    assert image_index < total_images, \\\n",
+    "    f'Please specify an image index less than {total_images}. Index provided: {image_index}.'\n",
+    "    \n",
+    "    # Read input image\n",
+    "    input_image = cv2.imread(original_images[image_index])\n",
+    "    \n",
+    "    # Pre-process image\n",
+    "    image_data = preprocess(input_image)\n",
+    "    \n",
+    "    # Fetch data to DPU and trigger it\n",
+    "    image[0, ...] = image_data\n",
+    "    job_id = dpu.execute_async(input_data, output_data)\n",
+    "    dpu.wait(job_id)\n",
+    "    \n",
+    "    # Post-process result\n",
+    "    postprocess(input_image, output_data, display, score_threshold=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce5054ee-a60c-4be6-a218-fa94592f543c",
+   "metadata": {},
+   "source": [
+    "Let's run it for 1 image and display the annotated image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cb45284-6fb0-475c-98af-d8e41b44c1d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(0, display=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29ebd8d8-f020-4444-bda6-00790a34ca4a",
+   "metadata": {},
+   "source": [
+    "We can also run it for multiple images as shown below. In this example we have only used 1 thread; in principle, users should be able to boost the performance by employing more threads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c6ba486-ab82-4730-b30a-7c053fffa154",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time1 = time.time()\n",
+    "[run(i) for i in range(total_images)]\n",
+    "time2 = time.time()\n",
+    "fps = total_images/(time2-time1)\n",
+    "print(\"Performance: {} FPS\".format(fps))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33d1d65c-a33d-4c3e-b550-a458683062ad",
+   "metadata": {},
+   "source": [
+    "We will need to remove references to `vart.Runner` and let Python garbage-collect the unused graph objects. This will make sure we can run other notebooks without any issue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acf241ac-0f94-4055-be79-1d4fa1c4b26d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del dpu\n",
+    "del ol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c2d276f-574f-4b68-8794-6d93f4c133b8",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "Copyright (C) 2021 Xilinx, Inc\n",
+    "\n",
+    "SPDX-License-Identifier: Apache-2.0 License\n",
+    "\n",
+    "----\n",
+    "\n",
+    "----"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pynq_dpu/notebooks/dpu_semantic_fpn.ipynb
+++ b/pynq_dpu/notebooks/dpu_semantic_fpn.ipynb
@@ -1,0 +1,397 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fca39180-b0bc-45d4-be84-9e36e6153e51",
+   "metadata": {},
+   "source": [
+    "# DPU example: Semantic-FPN\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3016107-ad69-4752-82de-39f69287abae",
+   "metadata": {},
+   "source": [
+    "## Aim/s\n",
+    "* This notebooks shows an example of DPU applications. The application, as well as the DPU IP, is pulled from the official \n",
+    "[Vitis AI Github Repository](https://github.com/Xilinx/Vitis-AI).\n",
+    "* Description: Semantic-FPN for segmentation on Cityscapes.\n",
+    "* Input size: 1024x512\n",
+    "* Task: Segmentation\n",
+    "\n",
+    "## References\n",
+    "* [Vitis AI Github Repository](https://www.xilinx.com/products/design-tools/vitis/vitis-ai.html).\n",
+    "\n",
+    "## Last revised\n",
+    "* December 14, 2023\n",
+    "    * Initial revision. MM, Alpha Data Parallel Systems Ltd.\n",
+    "\n",
+    "----"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "468bddfe-d28e-47c9-b9dc-ccfb136b1728",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import glob\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import IPython\n",
+    "from PIL import Image\n",
+    "\n",
+    "from pynq_dpu import DpuOverlay"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc447f4c-5abb-4fb9-8127-b528f5111ca4",
+   "metadata": {},
+   "source": [
+    "## 1. Prepare the overlay\n",
+    "We will download the overlay onto the board and prepare the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9803d26-f3d4-4e44-8bf7-de75f85dc9aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ol = DpuOverlay('dpu.bit')\n",
+    "ol.load_model('pt_SemanticFPN-mobilenetv2.xmodel')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0368ac3f-877e-4b02-8c2a-bc7cf97c70ef",
+   "metadata": {},
+   "source": [
+    "## 2. Utility functions\n",
+    "\n",
+    "In this section, we will prepare a few functions and the input data for later use.\n",
+    "\n",
+    "First we need to define helper functions to prepare the input images for the model. At this\n",
+    "stage we will also define a post-processing function to decode the output of the model and\n",
+    "apply a color palette to annotated the semantic information of the image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fd0c52a-3178-4adf-b2e5-ba56f8b20ec4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MEAN = (123.675, 116.28, 103.53)\n",
+    "STD = (58.395, 57.12, 57.375)\n",
+    "\n",
+    "def preprocess(image, size=(1024, 512)):\n",
+    "    '''\n",
+    "    Function to prepare the input for the Semantic-FPN model.\n",
+    "    The input images are first converted to the RGB color space,\n",
+    "    then resized and finally shifted and scaled to standardise the\n",
+    "    color channel values.\n",
+    "    \n",
+    "    Args:\n",
+    "        image: 3 dimensional array corresponding to the input BGR image.\n",
+    "        size (optional): (new_width, new_height) tuple corresponding to \n",
+    "                         the size of the input the Semantic-FPN model is\n",
+    "                         expecting. Set to 1024x512 by default.\n",
+    "        \n",
+    "    Returns:\n",
+    "        3 dimensional array corresponding to the input for Semantic-FPN.\n",
+    "        The array has a shape of (new_height, new_width, 3).\n",
+    "    '''\n",
+    "    rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)\n",
+    "    resized_image = cv2.resize(rgb_image, size, interpolation=cv2.INTER_LINEAR)\n",
+    "    processed_image = (resized_image - MEAN) / STD\n",
+    "    return processed_image.astype(np.float32)\n",
+    "\n",
+    "def get_palette():\n",
+    "    '''\n",
+    "    Function to generate the color palette to annotate the semantic information.\n",
+    "    \n",
+    "    Returns:\n",
+    "        2 dimensional array of the shape (256, 3) corresponding to the color\n",
+    "        values for each channel of the colorised image. While only 19 classes\n",
+    "        are predicted by the model, the cv2.LUT function requires a palette for\n",
+    "        all 256 possible values of the 8-bit unsigned integers in the mask.\n",
+    "    '''\n",
+    "    palette = [128, 64, 128,\n",
+    "               244, 35, 232,\n",
+    "               70, 70, 70,\n",
+    "               102, 102, 156,\n",
+    "               190, 153, 153,\n",
+    "               153, 153, 153,\n",
+    "               250, 170, 30,\n",
+    "               220, 220, 0,\n",
+    "               107, 142, 35,\n",
+    "               152, 251, 152,\n",
+    "               70, 130, 180,\n",
+    "               220, 20, 60,\n",
+    "               255, 0, 0,\n",
+    "               0, 0, 142,\n",
+    "               0, 0, 70,\n",
+    "               0, 60, 100,\n",
+    "               0, 80, 100,\n",
+    "               0, 0, 230,\n",
+    "               119, 11, 32]\n",
+    "\n",
+    "    palette = palette + [0] * (256 * 3 - len(palette))\n",
+    "    \n",
+    "    return np.array(palette, dtype=np.uint8).reshape((-1, 3))\n",
+    "\n",
+    "PALETTE = get_palette()\n",
+    "\n",
+    "def colorise_mask(mask):\n",
+    "    '''\n",
+    "    Function to colorise the output mask of the model.\n",
+    "    \n",
+    "    Input:\n",
+    "        mask: 2 dimensional array corresponding to the color index of each\n",
+    "              pixel classified during segmentation.\n",
+    "    \n",
+    "    Returns:\n",
+    "        3 dimensional array corresponding to the image colorised according to\n",
+    "        the provided mask.\n",
+    "    '''\n",
+    "    uint_mask = mask.astype(np.uint8)\n",
+    "    channels = [cv2.LUT(uint_mask, PALETTE[:, i]) for i in range(3)]\n",
+    "    return np.dstack(channels)\n",
+    "\n",
+    "def postprocess(output_tensors):\n",
+    "    '''\n",
+    "    Function to decode the output of the model and colorise the segmenation\n",
+    "    results.\n",
+    "    \n",
+    "    Input:\n",
+    "        output_tensors: buffers allocated for the DPU to store the output of\n",
+    "                        the model.\n",
+    "    \n",
+    "    Returns:\n",
+    "        3 dimensional array corresponding to the image colorised according to\n",
+    "        the output of the model.\n",
+    "    '''\n",
+    "    output = output_tensors[0][0]\n",
+    "    seg_pred = np.argmax(output, axis=2)\n",
+    "    return colorise_mask(seg_pred)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a34e5f6-b364-4c1f-a862-df02e16d7c81",
+   "metadata": {},
+   "source": [
+    "Finally, use a search pattern to collect all the `png` files for segmentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1082ec32-ef15-465b-928a-8c661800987c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_pattern = r'img/segm/*.png'\n",
+    "original_images = glob.glob(search_pattern)\n",
+    "total_images = len(original_images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d60f3a57-59f1-4bbf-a31b-ff6e50cc26ed",
+   "metadata": {},
+   "source": [
+    "## 3. Use VART\n",
+    "\n",
+    "Now we should be able to use VART to do semantic segmentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6ffc712-f94f-46d4-99f6-b56715b64bf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dpu = ol.runner\n",
+    "\n",
+    "input_tensors = dpu.get_input_tensors()\n",
+    "output_tensors = dpu.get_output_tensors()\n",
+    "\n",
+    "shape_in = input_tensors[0].dims\n",
+    "shape_out = output_tensors[0].dims"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f429d560-2109-4ebb-9a84-de116fa1062d",
+   "metadata": {},
+   "source": [
+    "We can define a few buffers to store input and output data. They will be reused during \n",
+    "multiple runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f0ee885-7136-4aee-97a1-7399735ace4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_data = [np.empty(shape_in, dtype=np.float32, order=\"C\")]\n",
+    "output_data = [np.empty(shape_out, dtype=np.float32, order=\"C\")]\n",
+    "\n",
+    "image = input_data[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46ce8faf-829f-4ece-9374-f1cd69e38d3d",
+   "metadata": {},
+   "source": [
+    "Remember that we have a list of `original_images`. We can no define a new function `run()` which takes the image index as the input, prepares the image for the model, executes the DPU for the given input and finally post-processes the output of the DPU. With the argument \n",
+    "`display` set to `True`, the colorised output of the model is displayed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0392891-d799-449c-ab58-aae4fb5b6b31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run(image_index, display=False):\n",
+    "    '''\n",
+    "    Function to handle a single input for the DPU and process the output of the run.\n",
+    "    \n",
+    "    Args:\n",
+    "        image_index: int corresonding to the index of the collected images to be processed.\n",
+    "        display (optional): boolean flag set to annotate and display the input image.\n",
+    "        \n",
+    "    Returns:\n",
+    "        None, the annotated image is displayed when the display flag is set.\n",
+    "        \n",
+    "    Raises:\n",
+    "        AssertionError: when the provided image_index is larger than the number of potential\n",
+    "                        input images found.\n",
+    "    \n",
+    "    '''\n",
+    "    assert image_index < total_images, \\\n",
+    "    f'Please specify an image index less than {total_images}. Index provided: {image_index}.'\n",
+    "    \n",
+    "    # Read input image\n",
+    "    input_image = cv2.imread(original_images[image_index])\n",
+    "    \n",
+    "    # Pre-processing\n",
+    "    image_data = preprocess(input_image)\n",
+    "    \n",
+    "    # Fetch data to DPU and trigger it\n",
+    "    image[...] = image_data\n",
+    "    job_id = dpu.execute_async(input_data, output_data)\n",
+    "    dpu.wait(job_id)\n",
+    "    \n",
+    "    # Post-processing\n",
+    "    output_image = postprocess(output_data)\n",
+    "    \n",
+    "    if display:\n",
+    "        IPython.display.display(Image.fromarray(output_image))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa70895e-55b4-4cf2-ba17-4380cd23dc48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(0, display=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac328e7d-a7d3-4a99-b761-d1ebf478e5ed",
+   "metadata": {},
+   "source": [
+    "We can also run it for multiple images as shown below. In this example we have only used 1 thread; in principle, users should be able to boost the performance by employing more threads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83ca2fa1-46f5-47fe-9e0d-337c6da9537b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time1 = time.time()\n",
+    "[run(i) for i in range(total_images)]\n",
+    "time2 = time.time()\n",
+    "fps = total_images/(time2-time1)\n",
+    "print(\"Performance: {} FPS\".format(fps))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "731fc7a8-4e38-4071-8180-da9ada0fbb89",
+   "metadata": {},
+   "source": [
+    "We will need to remove references to `vart.Runner` and let Python garbage-collect the unused graph objects. This will make sure we can run other notebooks without any issue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2dfe33d-0937-4771-b69f-b2f454c9e326",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del dpu\n",
+    "del ol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5ff51c3-1664-4bca-b4c2-83297b7f2b22",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "Copyright (C) 2021 Xilinx, Inc\n",
+    "\n",
+    "SPDX-License-Identifier: Apache-2.0 License\n",
+    "\n",
+    "----\n",
+    "\n",
+    "----"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pynq_dpu/notebooks/refinedet_utils.py
+++ b/pynq_dpu/notebooks/refinedet_utils.py
@@ -1,0 +1,299 @@
+# Copyright 2019 Xilinx Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# bash
+
+import numpy as np
+import itertools
+import time
+import math
+
+def center2point(center_x, center_y, width, height):
+    return center_x - width / 2., center_y - height / 2., center_x + width / 2., center_y + height / 2.
+
+def point2center(xmin, ymin, xmax, ymax):
+    width, height = (xmax - xmin), (ymax - ymin)
+    return xmin + width / 2., ymin + height / 2., width, height
+
+def clip(xmin, ymin, xmax, ymax, min_value=0.0, max_value=1.0):
+    xmin, ymin = np.clip(xmin, min_value, max_value), np.clip(ymin, min_value, max_value)
+    xmax, ymax = np.clip(xmax, min_value, max_value), np.clip(ymax, min_value, max_value)
+    return xmin, ymin, xmax, ymax
+
+# This function is from https://github.com/kuangliu/pytorch-ssd.
+def calc_iou_tensor(box1, box2):
+    """ Calculation of IoU based on two boxes tensor,
+        Reference to https://github.com/kuangliu/pytorch-ssd
+        input:
+            box1 (N, 4) 
+            box2 (M, 4)
+        output:
+            IoU (N, M)
+    """
+    N = box1.shape[0]
+    M = box2.shape[0]
+
+    be1 = np.expand_dims(box1, 1).repeat(M, axis=1)
+    be2 = np.expand_dims(box2, 0).repeat(N, axis=0)
+    lt = np.maximum(be1[:,:,:2], be2[:,:,:2])
+    rb = np.minimum(be1[:,:,2:], be2[:,:,2:])
+
+    delta = rb - lt
+    delta[delta < 0] = 0
+    intersect = delta[:,:,0]*delta[:,:,1]
+
+    delta1 = be1[:,:,2:] - be1[:,:,:2]
+    area1 = delta1[:,:,0]*delta1[:,:,1]
+    delta2 = be2[:,:,2:] - be2[:,:,:2]
+    area2 = delta2[:,:,0]*delta2[:,:,1]
+
+    iou = intersect/(area1 + area2 - intersect)
+    return iou
+
+def softmax_cpu(x, dim=-1):
+    x = np.exp(x)
+    s = np.expand_dims(np.sum(x, axis=dim), dim)
+    return x/s
+
+def pboxes_vgg_voc():
+    input_shape = [320, 320]
+    feature_shapes = [(40, 40), (20, 20), (10, 10), (5, 5)] 
+    min_sizes = [(32,), (64,), (128,), (256,)] 
+    max_sizes = [(64,), (128,), (256,), (315,)] 
+    aspect_ratios = [(2.,), (2.,), (2.,), (2.,)] 
+    steps = [(8, 8), (16, 16), (32, 32), (64, 64)]  
+    offset=0.5
+    pboxes = Priorbox(input_shape, feature_shapes, min_sizes, max_sizes, aspect_ratios, steps)
+
+    return pboxes
+
+# This function is from https://github.com/kuangliu/pytorch-ssd.
+class Encoder(object):
+    """
+        Inspired by https://github.com/kuangliu/pytorch-ssd
+        Transform between (bboxes, lables) <-> SSD output
+        
+        dboxes: default boxes in size 8732 x 4, 
+            encoder: input ltrb format, output xywh format
+            decoder: input xywh format, output ltrb format 
+        
+        decode:
+            input  : bboxes_in (Tensor 8732 x 4), scores_in (Tensor 8732 x nitems)
+            output : bboxes_out (Tensor nboxes x 4), labels_out (Tensor nboxes)
+            criteria : IoU threshold of bboexes
+            max_output : maximum number of output bboxes
+    """
+
+    def __init__(self, pboxes):
+        self.pboxes = pboxes(order="ltrb")
+        #self.dboxes_xywh = dboxes(order="xywh").unsqueeze(dim=0)
+        self.pboxes_xywh = pboxes(order="xywh")
+        self.nboxes = self.pboxes.shape[0]
+        #print("# Bounding boxes: {}".format(self.nboxes))
+        self.scale_xy = pboxes.scale_xy
+        self.scale_wh = pboxes.scale_wh
+
+    def scale_back_batch(self, arm_scores_in, arm_bboxes_in, odm_scores_in, odm_bboxes_in, device):
+        """
+            Do scale and transform from xywh to ltrb
+            suppose input Nx4xnum_bbox Nxlabel_numxnum_bbox
+        """
+        
+        arm_bboxes_in[:, :, :2] = self.scale_xy*arm_bboxes_in[:, :, :2]
+        arm_bboxes_in[:, :, 2:] = self.scale_wh*arm_bboxes_in[:, :, 2:]
+        odm_bboxes_in[:, :, :2] = self.scale_xy*odm_bboxes_in[:, :, :2]
+        odm_bboxes_in[:, :, 2:] = self.scale_wh*odm_bboxes_in[:, :, 2:]
+        
+        for idx in range(arm_bboxes_in.shape[0]):
+            arm_bboxes_in[idx, :, :2] = arm_bboxes_in[idx, :, :2]*self.pboxes_xywh[:, 2:] + self.pboxes_xywh[:, :2]
+            arm_bboxes_in[idx, :, 2:] = np.exp(arm_bboxes_in[idx, :, 2:])*self.pboxes_xywh[:, 2:]
+         
+            odm_bboxes_in[idx, :, :2] = odm_bboxes_in[idx, :, :2]*arm_bboxes_in[idx, :, 2:] + arm_bboxes_in[idx, :, :2]
+            odm_bboxes_in[idx, :, 2:] = np.exp(odm_bboxes_in[idx, :, 2:])*arm_bboxes_in[idx, :, 2:]
+
+        # Transform format to ltrb 
+        l, t, r, b = odm_bboxes_in[:, :, 0] - 0.5*odm_bboxes_in[:, :, 2],\
+                     odm_bboxes_in[:, :, 1] - 0.5*odm_bboxes_in[:, :, 3],\
+                     odm_bboxes_in[:, :, 0] + 0.5*odm_bboxes_in[:, :, 2],\
+                     odm_bboxes_in[:, :, 1] + 0.5*odm_bboxes_in[:, :, 3]
+        
+        l, t, r, b = clip(l, t, r, b)
+        odm_bboxes_in[:, :, 0] = l
+        odm_bboxes_in[:, :, 1] = t
+        odm_bboxes_in[:, :, 2] = r
+        odm_bboxes_in[:, :, 3] = b
+        #w = r - l
+        #h = b - t
+                
+        arm_scores_in = softmax_cpu(arm_scores_in, dim=-1)
+        odm_scores_in = softmax_cpu(odm_scores_in, dim=-1)
+        
+        arm_mask = arm_scores_in[:, :, 1] <= 0.01
+        arm_mask = np.tile(np.expand_dims(arm_mask, -1), (1, 1, odm_scores_in.shape[-1]))
+        #odm_scores_in[w <= 0.003] = 0.0
+        #odm_scores_in[h <= 0.003] = 0.0 
+        odm_scores_in[arm_mask] = 0.0
+
+        return odm_bboxes_in, odm_scores_in
+   
+    def decode_batch(self, arm_scores_in, arm_bboxes_in, odm_scores_in, odm_bbxoes_in, criteria = 0.45, max_output=200,device=0):
+        bboxes, probs = self.scale_back_batch(arm_scores_in, arm_bboxes_in, odm_scores_in, odm_bbxoes_in, device)
+        output = []
+        for bbox, prob in zip(bboxes, probs):
+            output.append(self.decode_single(bbox, prob, criteria, max_output))
+            #print(output[-1])
+        return output
+
+    # perform non-maximum suppression
+    def decode_single(self, bboxes_in, scores_in, criteria, max_output, max_num=200):
+        # Reference to https://github.com/amdegroot/ssd.pytorch
+       
+        bboxes_out = []        
+        scores_out = []
+        labels_out = []
+
+        for i, score in enumerate(np.split(scores_in, scores_in.shape[1], 1)):
+            # skip background
+            # print(score[score>0.90])
+            if i == 0: continue
+            score = score.squeeze(1)
+            mask = score > 0.005
+
+            bboxes, score = bboxes_in[mask, :], score[mask]
+            if score.shape[0] == 0: continue
+
+            score_sorted = np.sort(score, axis=0)
+            score_idx_sorted = np.argsort(score, axis=0)
+
+            # select max_output indices
+            score_idx_sorted = score_idx_sorted[-max_num:]
+            candidates = []
+        
+            while score_idx_sorted.size > 0:
+                idx = score_idx_sorted[-1].item()
+                bboxes_sorted = bboxes[score_idx_sorted, :]
+                bboxes_idx = np.expand_dims(bboxes[idx, :],0)
+                iou_sorted = calc_iou_tensor(bboxes_sorted, bboxes_idx).squeeze()
+                # we only need iou < criteria 
+                score_idx_sorted = score_idx_sorted[iou_sorted < criteria]
+                candidates.append(idx)
+
+            bboxes_out.append(bboxes[candidates, :])
+            scores_out.append(score[candidates])
+            labels_out.extend([i]*len(candidates))
+
+        bboxes_out = np.concatenate(bboxes_out, axis=0)
+        labels_out = np.array(labels_out, dtype=np.int32)
+        scores_out = np.concatenate(scores_out, axis=0)
+
+        max_ids = np.argsort(scores_out, axis=0)
+        max_ids = max_ids[-max_output:]
+        return bboxes_out[max_ids, :], labels_out[max_ids], scores_out[max_ids]
+
+class Priorbox(object):
+ 
+    def __init__(self, input_shape, feature_shapes, min_sizes, max_sizes, aspect_ratios, steps, 
+                 offset=0.5, priorbox_order=False, clip=False, scale_xy=0.1, scale_wh=0.2):
+        ''' Priorbox class
+        Args:
+          input_shape: shape of network input.
+          feature_shapes: shapes(h, w) list of detection heads feature map.
+          min_sizes: list of min sizes.
+          max_sizes: list of max sizes.
+          aspect_ratios: list of prior apsect ratios per piexl.
+          steps: list of steps
+          prior_order: num_prior * h * w if false else h * w * num_prior  
+          clip: whether prior need clip or not. 
+        '''
+        super(Priorbox, self).__init__()
+       
+        self.input_shape = input_shape
+        self.feature_shapes = feature_shapes
+        self.min_sizes = min_sizes
+        self.max_sizes = max_sizes
+        self.aspect_ratios = aspect_ratios
+        self.steps = steps
+        self.offsets = [offset] * len(steps) 
+        self.priorbox_order = priorbox_order
+        self.clip = clip
+
+        self.scale_xy_ = scale_xy
+        self.scale_wh_ = scale_wh
+
+        prior_boxes = []
+           
+        for idx, feature_shape in enumerate(self.feature_shapes):
+            f_h, f_w = feature_shape
+            step = self.steps[idx]
+            f_h_s = float(self.input_shape[0]) / step[0]
+            f_w_s = float(self.input_shape[1]) / step[1]
+            offset = self.offsets[idx]
+            min_size = self.min_sizes[idx]
+            if self.max_sizes:
+                max_size = self.max_sizes[idx]
+            
+            prior_whs_ratios = []
+            for size in min_size:
+                p_w = float(size) / self.input_shape[1]
+                p_h = float(size) / self.input_shape[0]
+                prior_whs_ratios.append((p_w, p_h))
+            if self.max_sizes:
+                for sizes in zip(min_size, max_size):
+                    size = math.sqrt(sizes[0] * sizes[1])   
+                    p_w = size / self.input_shape[1]
+                    p_h = size / self.input_shape[0]
+                    prior_whs_ratios.append((p_w, p_h))
+
+            for size in min_size:
+                for alpha in self.aspect_ratios[idx]:
+                    s_alpha = math.sqrt(alpha)
+                    p_w = float(size) / self.input_shape[1]
+                    p_h = float(size) / self.input_shape[0]
+                    prior_whs_ratios.append((p_w * s_alpha, p_h / s_alpha))
+                    prior_whs_ratios.append((p_w / s_alpha, p_h * s_alpha)) 
+        
+            if not self.priorbox_order:
+                for (h, w) in itertools.product(range(f_h), range(f_w)):
+                    cx = (w + offset) / f_w_s
+                    cy = (h + offset) / f_h_s
+                    for p_wh in prior_whs_ratios:
+                        prior_boxes.append([cx, cy, p_wh[0], p_wh[1]])  
+            else:
+                for p_wh in prior_whs_ratios:
+                    for (h, w) in itertools.product(range(f_h), range(f_w)):
+                        cx = (w + offset) / f_w_s
+                        cy = (h + offset) / f_h_s
+                        prior_boxes.append([cx, cy, p_wh[0], p_wh[1]])
+
+        prior_boxes_ltrb = [list(center2point(*prior_box)) for prior_box in prior_boxes]           
+        if self.clip:
+             prior_boxes_ltrb = [list(clip(*prior_box_ltrb)) for prior_box_ltrb in prior_boxes_ltrb]           
+             prior_boxes = [list(point2center(*prior_box_ltrb)) for prior_box_ltrb in prior_boxes_ltrb]
+
+        self.pboxes = np.array(prior_boxes)
+        self.pboxes_ltrb = np.array(prior_boxes_ltrb)
+
+    @property
+    def scale_xy(self):
+        return self.scale_xy_
+    
+    @property    
+    def scale_wh(self):
+        return self.scale_wh_
+
+    def __call__(self, order="ltrb"):
+        if order == "ltrb": return self.pboxes_ltrb
+        if order == "xywh": return self.pboxes
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
Hi,

Two examples notebooks were added for Object Detection with RefineDet and Semantic Segmentation with Semantic-FPN. The notebooks use the VOC and Cityscapes example images already in the branch.

Origin of models:
- RefineDet: [tf_refinedet_VOC_320_320_81.9G](https://github.com/Xilinx/Vitis-AI/blob/1.4/models/AI-Model-Zoo/model-list/tf_refinedet_VOC_320_320_81.9G_1.4/model.yaml)
- Semantic-FPN: [pt_SemanticFPN-mobilenetv2_cityscapes_512_1024_5.4G](https://github.com/Xilinx/Vitis-AI/blob/1.4/models/AI-Model-Zoo/model-list/pt_SemanticFPN-mobilenetv2_cityscapes_512_1024_5.4G_1.4/model.yaml)

Testing details:
- Board: [ADM-XRC-9Z1](https://www.alpha-data.com/product/adm-xrc-9z1/) Custom Zynq UltraScale+ MPSoC
- PYNQ image version: 2.7.0
- DPU-PYNQ version: 1.4.0